### PR TITLE
fix: rmdir will cause callback twice, using xfs instead

### DIFF
--- a/lib/admin/single_api/app.js
+++ b/lib/admin/single_api/app.js
@@ -3,7 +3,6 @@
 const fs = require('xfs');
 const _ = require('lodash');
 const path = require('path');
-const rmdir = require('rmdir');
 const async = require('async');
 const formidable = require('formidable');
 
@@ -30,7 +29,7 @@ exports.stopApp = function (req, res, next) {
       });
     },
     function (info, callback) {
-      rmdir(appPkgDir, function (err) {
+      fs.rm(appPkgDir, function (err) {
         err = err && err.code === 'ENOENT' ? null : err;
         callback(err, info);
       });
@@ -64,13 +63,13 @@ exports.deleteApp = function (req, res, next) {
       });
     },
     function (callback) {
-      rmdir(appPkgDir, function (err) {
+      fs.rm(appPkgDir, function (err) {
         err = err && err.code === 'ENOENT' ? null : err;
         callback(err);
       });
     },
     function (callback) {
-      rmdir(appPkgDir + '.tgz', function (err) {
+      fs.rm(appPkgDir + '.tgz', function (err) {
         err = err && err.code === 'ENOENT' ? null : err;
         callback(err);
       });
@@ -96,7 +95,7 @@ exports.startApp = function (req, res, next) {
   let appPkgDir = path.join(config.appsRoot, appid);
   async.waterfall([
     function (callback) {
-      rmdir(appPkgDir, function (err) {
+      fs.rm(appPkgDir, function (err) {
         detailInfos.push('[' + new Date() + '] Delete the dir of ' + appid);
         err = err && err.code === 'ENOENT' ? null : err;
         callback(err);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "honeycomb-server",
   "version": "1.0.6",
-  "build": "1",
+  "build": "2",
   "description": "Honeycomb, the micro-app's container",
   "repository": {
     "type": "git",
@@ -26,9 +26,8 @@
     "mkdirp": "0.5.1",
     "pidusage": "1.2.0",
     "randomatic": "3.0.0",
-    "rmdir": "1.2.0",
     "slice-file": "1.0.0",
-    "urllib": "2.25.3",
+    "urllib": "2.27.0",
     "uuid": "3.1.0",
     "xfs": "0.2.3",
     "yamljs": "0.3.0"

--- a/test/lib/admin/api_app.test.js
+++ b/test/lib/admin/api_app.test.js
@@ -142,6 +142,26 @@ describe('api app test: ', () => {
     });
   });
 
+  describe('delete app', () => {
+    it('should return error when unmount error', (done) => {
+      let master = common.getMaster();
+      mm(master, '$unmount', function (appId, cb) {
+        cb(new Error('mock_error'));
+      });
+      common.deleteApp(agent, ips, 'app-not-exist')
+        .expect(200)
+        .expect((res)=>{
+          res.body.error.length.should.eql(1);
+          res.body.error[0].code.should.eql('DELETE_APP_ERROR');
+          res.body.error[0].message.should.eql('mock_error');
+        })
+        .end(() => {
+          mm.restore();
+          done();
+        });
+    });
+  });
+
   describe('reload app', () => {
     let request2 = supertest('http://localhost:8080');
     let oldWorkers;
@@ -232,6 +252,23 @@ describe('api app test: ', () => {
               });
             })
             .end(done);
+        });
+    });
+    it('should return when $mount failed', (done) => {
+      let master = common.getMaster();
+      mm(master, '$mount', function (appId, options, cb) {
+        cb(new Error('mock_error'));
+      });
+      common.restartApp(agent, ips, 'app-not-exist')
+        .expect(200)
+        .expect((res)=>{
+          res.body.error.length.should.eql(1);
+          res.body.error[0].code.should.eql('RESTART_APP_ERROR');
+          res.body.error[0].message.should.eql('mock_error');
+        })
+        .end(() => {
+          mm.restore();
+          done();
         });
     });
   });


### PR DESCRIPTION
rmdir包里的依赖：node.flow  可能存在双重callback的情况，外层的async监测到并抛错了。

使用xfs.rm替换掉rmdir