### PR TITLE
fix: default publish page should work fine when 9999 port is proxyed …

### DIFF
--- a/lib/admin/view/publish.html
+++ b/lib/admin/view/publish.html
@@ -32,7 +32,7 @@
   <body>
   <% if(publishPage === 'true'){ %>
 
-    <form id="uploadApp" onsubmit="return upload(this)" action="/api/defaultPublish" method="post" enctype='multipart/form-data'>
+    <form id="uploadApp" onsubmit="return upload(this)" action="./api/defaultPublish" method="post" enctype='multipart/form-data'>
       <h2>Install App</h2>
       <p class="desc">
         this page is only for init honeycomb-console.<br/>

--- a/lib/proxy/nginx.js
+++ b/lib/proxy/nginx.js
@@ -4,7 +4,6 @@ const fs = require('xfs');
 const _ = require('lodash');
 const child = require('child_process');
 const path = require('path');
-const debug = require('debug')('nginx');
 const xfs = require('xfs');
 const log = require('../../common/log');
 const utils = require('../../common/utils');
@@ -215,7 +214,7 @@ class Nginx extends Proxy {
     this.updateConfig(callback);
   }
   updateConfig(done) {
-    debug('update router');
+    log.debug('update router');
     let map = this.map;
     let config = {
       http: {
@@ -343,7 +342,7 @@ class Nginx extends Proxy {
    * reload nginx
    */
   reload(callback) {
-    debug('reload nginx');
+    log.debug('start reload nginx');
     this.flagReload = true;
     let cmdCheck = this.binPath + ' -t -c ' + this.configPath;
     let cmdReload = this.binPath + ' -s reload -c ' + this.configPath +
@@ -351,7 +350,6 @@ class Nginx extends Proxy {
     child.exec(cmdCheck, (err, stdout, stderr) => {
       if (err) {
         log.error(FLAG_NGINX, 'nginx_config_error ', stderr.toString());
-
         if (!this.flagRollBack) {
           this.flagRollBack = true;
           this.backupErrorConfig();
@@ -359,10 +357,12 @@ class Nginx extends Proxy {
         }
         return callback && callback(new Error('nginx reload failed, config error:' + err));
       }
+      log.debug('check nginx config success', stdout.toString());
       /**
        * get old nginx process worker's pids
        */
       this.getNginxWorkerPids((err, ngWorkers) => {
+        log.debug('get nginx old workers', ngWorkers);
         child.exec(cmdReload, (err, stdout, stderr) => {
           if (err) {
             err.message += ' ' + stderr.toString();
@@ -379,6 +379,7 @@ class Nginx extends Proxy {
           } else {
             this.flagRollBack = false;
           }
+          log.debug('nginx reload success');
           /** check if all old ng worker are stoped */
           this.checkNginxProcess(ngWorkers, null, callback);
         });
@@ -406,13 +407,16 @@ class Nginx extends Proxy {
   checkNginxProcess(workers, count, done) {
     let a = 0;
     count = count || 300;
+    log.debug('checking nginx old workers');
     function check() {
       if (!workers.length) {
+        log.debug('nginx old workers all stoped');
         return done();
       }
       child.exec('ps -p ' + workers.join(','), (err) => {
         if (err || a >= count) {
           // 老进程全部退去，可以返回
+          log.debug('nginx old workers force killed');
           return done && done();
         }
         a++;
@@ -427,7 +431,7 @@ class Nginx extends Proxy {
    * @return {Boolean} true 表示变化了，false表示没变化
    */
   flushConfig(config) {
-    debug('flush config');
+    log.debug('flush config');
     this.cleanConfig();
     // gen http Config
     let httpConfig = config.http;

--- a/nginx_sample.conf
+++ b/nginx_sample.conf
@@ -11,6 +11,13 @@ http {
     proxy_set_header X-Real-IP $remote_addr;
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+    server {
+      listen 8000;
+      location /__hc__/ {
+        proxy_pass http://127.0.0.1:9999/;
+      }
+    }
     # honeycomb hook
     # @honeycomb
+
 }


### PR DESCRIPTION
默认发布页在代理模式下也可以访问。

在容器中端口不透出的情况下，将控制端口和服务端口合并，通过设置nginx配置
```
server {
      listen 8000;  
      location /__hc__/ {
        proxy_pass http://127.0.0.1:9999/;
      }
 }
```
可以通过 endpoint`http://ip/__hc__/`的形式，