### PR TITLE
fix: catch child error

### DIFF
--- a/config/config_default.js
+++ b/config/config_default.js
@@ -53,7 +53,12 @@ module.exports = {
    * !各应用的公共配置，会merge到各应用中
    * @type {Object}
    */
-  appsCommon: {},
+  appsCommon: {
+    /**
+     * https请求忽略证书异常
+     */
+    honeycomb: {env: {NODE_TLS_REJECT_UNAUTHORIZED: 0}},
+  },
   /**
    * app启动状态存储文件，一般不需要修改
    * @internal

--- a/lib/master.js
+++ b/lib/master.js
@@ -219,6 +219,10 @@ Master.prototype._fork = function (appId, options, cb) {
     message.receive(msg, childProc, this);
   });
 
+  child.on('error', (err) => {
+    log.error(`child ${appId} error`, err);
+  });
+
   /**
    * @param {Object} options
    *   - file


### PR DESCRIPTION
非node的 service类型的child异常时，捕获抛出的异常 