### PR TITLE
fix: catch cb throw to prevent server crash

### DIFF
--- a/lib/admin/gather_usage.js
+++ b/lib/admin/gather_usage.js
@@ -70,6 +70,9 @@ function initGatherUsage() {
         });
 
         tasks.push((callback) => {
+          // TODO
+          // spawn, execFile 需要 try catch, 机器没内存时是同步报错，无法捕获
+          // Error: spawn ENOMEM
           free.m((err, info) => {
             if (err) {
               log.warn('get free memory failed:', err.message);

--- a/lib/admin/single_api/app.js
+++ b/lib/admin/single_api/app.js
@@ -323,10 +323,10 @@ exports.publishApp = function (req, res, next) {
           utils.exec(hooks.publish, {
             cwd: appRoot,
             maxBuffer: 128 * 1024 * 1024,
-            env: {
+            env: Object.assign({
               HC_APP_ID: appId,
               HC_APP_MAIN: path.join(appRoot, pkg.main || '')
-            }
+            }, process.env)
           }, callback);
         } else if (typeof hooks.publish === 'function') {
           try {

--- a/lib/proxy/nginx.js
+++ b/lib/proxy/nginx.js
@@ -419,7 +419,7 @@ class Nginx extends Proxy {
                 };
               }
               if (this.options.index) {
-                defaultServerCfg.locations['/'] = {
+                defaultServerCfg.locations['= /'] = {
                   redirect: fixRedirectIndex(this.options.index)
                 };
               }
@@ -462,7 +462,7 @@ class Nginx extends Proxy {
 
                 /** 初始化时定义，当router为/时，可覆盖，不影响自定义路由 */
                 if (this.options.serverIndexs[serverName]) {
-                  ngConfig.servers[key].locations['/'] = {
+                  ngConfig.servers[key].locations['= /'] = {
                     redirect: this.options.serverIndexs[serverName]
                   };
                 }
@@ -816,7 +816,7 @@ class Nginx extends Proxy {
           alias: v.file
         }]);
       } else if (v.redirect) {
-        router = '= ' + router;
+        // router = '= ' + router;
         let redirect = v.redirect.startsWith('http') ? v.redirect : '$scheme://$http_host' + v.redirect;
         reservedRules.push([router, {
           return: `301 ${redirect}`

--- a/lib/proxy/node_proxy/http.js
+++ b/lib/proxy/node_proxy/http.js
@@ -265,7 +265,12 @@ class HttpProxy {
         // serverName and router match
         if (pathname.indexOf(app.router) === 0) {
           log.debug(FLAG_PROXY, 'match', app.appId, app.match);
-          return cb(null, app, headers);
+          try {
+            // cb maybe throw
+            return cb(null, app, headers);
+          } catch(err) {
+            cb(err);
+          }
         }
       }
     }
@@ -277,7 +282,12 @@ class HttpProxy {
         // serverName and router match
         if (pathname.indexOf(app.router) === 0) {
           log.debug(FLAG_PROXY, 'match', app.appId, req.url);
-          return cb(null, app, headers);
+          try {
+            // cb maybe throw
+            return cb(null, app, headers);
+          } catch(err) {
+            cb(err);
+          }
         }
       }
     }
@@ -290,7 +300,11 @@ class HttpProxy {
         return;
       }
       flagCB = true;
-      cb && cb();
+      try {
+        cb && cb();
+      } catch(e) {
+        console.log(e)
+      }
     }
     this.server.close(done);
     setTimeout(function () {

--- a/lib/proxy/node_proxy/http.js
+++ b/lib/proxy/node_proxy/http.js
@@ -302,8 +302,8 @@ class HttpProxy {
       flagCB = true;
       try {
         cb && cb();
-      } catch(e) {
-        console.log(e)
+      } catch(err) {
+        log.error(FLAG_PROXY, 'proxy server close callback error:', err.message);
       }
     }
     this.server.close(done);

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "honeycomb-server",
-  "version": "1.2.5",
-  "build": "2",
+  "version": "2.0.0",
+  "build": "1",
   "description": "Honeycomb, the micro-app's container",
   "repository": {
     "type": "git",
@@ -46,7 +46,7 @@
     "ws": "^3.3.2"
   },
   "engines": {
-    "install-alinode": "3.8.4"
+    "install-alinode": "5.13.0"
   },
   "scripts": {
     "test": "make test"

--- a/test/lib/proxy/nginx.test.js
+++ b/test/lib/proxy/nginx.test.js
@@ -1046,6 +1046,9 @@ describe('lib/proxy/nginx.js', () => {
     beforeEach(() => {
       mm.restore();
     });
+    afterEach(() => {
+      mm.restore();
+    });
     it('should work fine when workers is empty', (done) => {
       let ng = new Nginx(options);
       mm(child, 'exec', function (cmd, callback) {
@@ -1076,9 +1079,13 @@ describe('lib/proxy/nginx.js', () => {
     it('should work fine when workers when check multi time', (done) => {
       let ng = new Nginx(options);
       let a = 0;
-      mm(child, 'exec', function (cmd, callback) {
+      mm(child, 'exec', function (cmd, opt, callback) {
         a++;
-        callback(null);
+        if (!callback) {
+          callback = opt;
+          opt = {};
+        }
+        callback && callback(null);
       });
       ng.checkNginxProcess([1, 2, 3], 2, () => {
         a.should.eql(3);


### PR DESCRIPTION
实际使用中碰到cb异常没有接住，导致服务退出的情况。这个PR经过一定时间的测试，提高了服务稳定性。
最后一个cb的`console.log(e)`建议暂时先这样打印观察一阵，因为此时服务正在退出，尽量不引发关联问题。

