### PR TITLE
fs.writeFile & writeFileSync 方法的 data 入参必须传递符合 validateStringAfterArr…

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -68,7 +68,7 @@ Master.prototype.init = function (done) {
   utils.mkdirp(this.config.appsRoot);
   utils.mkdirp(path.join(this.config.proxy.nginxIncludePath, 'http'));
   utils.mkdirp(path.join(this.config.proxy.nginxIncludePath, 'stream'));
-  fs.writeFileSync(this.config.pidFile, process.pid);
+  fs.writeFileSync(this.config.pidFile, process.pid.toString());
   fs.writeFileSync(this.config.serverStatusFile, 'online');
   let self = this;
 

--- a/test/lib/admin/api_coredump.test.js
+++ b/test/lib/admin/api_coredump.test.js
@@ -19,7 +19,7 @@ describe('api_coredump.test.js', () => {
 
   it('should list coredump', (done) => {
     // mock file
-    fs.sync().save(path.join(__dirname, '../../../core.123'));
+    fs.sync().save(path.join(__dirname, '../../../core.123'), '');
     common.checkCoreDump(agent, ips)
       .expect(200)
       .expect('content-type', /application\/json/)
@@ -34,7 +34,7 @@ describe('api_coredump.test.js', () => {
       .end(done);
   });
   it('should delete coredump', (done) => {
-    fs.sync().save(path.join(__dirname, '../../../core.123'));
+    fs.sync().save(path.join(__dirname, '../../../core.123'), '');
     common.deleteCoreDump(agent, ips, {files: 'core.123'})
       .expect(200)
       .expect('content-type', /application\/json/)


### PR DESCRIPTION
fs.writeFile & writeFileSync 方法的 data 入参必须传递符合 validateStringAfterArrayBufferView 方法要求的数据类型否则会抛出 ERR_INVALID_ARG_TYPE 异常
参考:
fs.writeFile@nodejs12: https://github.com/nodejs/node/blob/v12.x/lib/fs.js#L1386
fs.writeFile@nodejs14: fs.https://github.com/nodejs/node/blob/v14.x/lib/fs.js#L1436
writeFile 新增了 validateStringAfterArrayBufferView 检查输入的 data，以往 data 不传值或者传入非预期类型的用法将会抛出异常：
❌ fs.writeFile(filePath)
❌ fs.writeFile(filePath, 123)