### PR TITLE
for compatibility with open source version of nginx, running -t also needs custom prefix

### DIFF
--- a/lib/proxy/nginx.js
+++ b/lib/proxy/nginx.js
@@ -505,7 +505,8 @@ class Nginx extends Proxy {
   reload(callback) {
     log.debug('start reload nginx');
     this.flagReload = true;
-    let cmdCheck = this.binPath + ' -t -c ' + this.configPath;
+    let cmdCheck = this.binPath + ' -t -c ' + this.configPath +
+      (this.prefixPath ? ' -p ' + this.prefixPath : '');
     let cmdReload = this.binPath + ' -s reload -c ' + this.configPath +
       (this.prefixPath ? ' -p ' + this.prefixPath : '');
     child.exec(cmdCheck, (err, stdout, stderr) => {


### PR DESCRIPTION
e.g. if with config: pid logs/aaaa.pid; if running -t without specifying
-p, it will give error: nginx: [emerg] open() "/etc/nginx/logs/aaaa.pid" failed (2: No such file or directory)