### PR TITLE
fix: env config in package.json not work

### DIFF
--- a/lib/master.js
+++ b/lib/master.js
@@ -511,7 +511,7 @@ Master.prototype.$mount = function (appId, options, cb) {
   /**
    * merge env from package.json
    */
-  if (pkg.honeycomb.env) {
+  if (pkg.honeycomb && pkg.honeycomb.env) {
     privateConfig.honeycomb.env = _.merge({}, privateConfig.honeycomb.env, pkg.honeycomb.env);
   }
 


### PR DESCRIPTION
With package.json file:

```json
{
  ...
  "honeycomb": {
    "processorNum": 1,
    "env": {
      "JAVA_OPTS": "xxxx"
    },
  ...
}
```

Running:
`grep JAVA_OPTS /proc/${pid}/environ`

Previous:
No output

Currently:
Binary file /proc/${pid}/environ matches

