### PR TITLE
fix: log file download

### DIFF
--- a/lib/admin/batch_api/log.js
+++ b/lib/admin/batch_api/log.js
@@ -153,16 +153,15 @@ exports.queryLogFiles = function (req, res) {
 };
 
 /**
- * @api {get} /api/log/:file
- * @desc 代理下载文件
+ * @api {get} /api/downloadLogFile
+ * @desc 下载&打包压缩日志文件
  *
  * @query
  *   ips {String} ips
- * @params
  *   file {String} fileName
  */
 exports.downloadLogFileBatch = function (req, res) {
-  const file = req.params.file;
+  const file = req.query.file;
 
   let ips = req.query.ips;
   ips = ips && ips.split(',');
@@ -174,8 +173,10 @@ exports.downloadLogFileBatch = function (req, res) {
     res.setHeader('Content-Disposition', `attachment; filename=${file}.gz.zip`);
     zipTransform.outputStream.pipe(res);
   }
-
-  let uri = `/api/single/log/${file}`;
+  const query = {
+    file
+  };
+  let uri = '/api/single/downloadLogFile?' + qs.stringify(query);
 
   utils.callremote(uri, {
     method: 'GET',

--- a/lib/admin/router.js
+++ b/lib/admin/router.js
@@ -107,7 +107,7 @@ module.exports = function (router) {
   router.delete('/api/single/coredump', ctrlAppSingle.deleteCoreDump);
   router.get('/api/single/unknowProcess', ctrlAppSingle.listUnknowProcess);
   router.delete('/api/single/unknowProcess/:pid', ctrlAppSingle.killUnknowProcess);
-  router.get('/api/single/log/:file', ctrlLogSingle.downloadLogFile);
+  router.get('/api/single/downloadLogFile', ctrlLogSingle.downloadLogFile);
 
   // batch api
   router.get('/api/apps', ctrlAppBatch.listApps);
@@ -126,7 +126,7 @@ module.exports = function (router) {
   router.delete('/api/coredump', ctrlAppBatch.deleteCoreDump);
   router.get('/api/unknowProcess', ctrlAppBatch.listUnknowProcess);
   router.delete('/api/unknowProcess/:pid', ctrlAppBatch.killUnknowProcess);
-  router.get('/api/log/:file', ctrlLogBatch.downloadLogFileBatch);
+  router.get('/api/downloadLogFile', ctrlLogBatch.downloadLogFileBatch);
 
   // router.get('/api/log', ctrlLogBatch.queryLogs);
   // router.get('/api/logs', ctrlLogBatch.queryLogFiles);

--- a/lib/admin/single_api/log.js
+++ b/lib/admin/single_api/log.js
@@ -252,7 +252,7 @@ exports.queryAppUsage = function (req, res) {
 };
 
 /**
- * @api {get} /api/single/log/:file
+ * @api {get} /api/single/downloadLogFile
  * @desc 下载单台机器的日志
  *
  * @query
@@ -261,7 +261,7 @@ exports.queryAppUsage = function (req, res) {
 exports.downloadLogFile = function (req, res) {
   const logRoot = config.logsRoot;
   const logFileDownloadRate = config.logFileDownloadRate;
-  const file = req.params.file;
+  const file = req.query.file;
 
   const logFile = path.join(logRoot, file);
   /**

--- a/test/common.js
+++ b/test/common.js
@@ -249,7 +249,7 @@ exports.getLog = (superAgent, ips, query) => {
 };
 
 exports.downloadLog = (superAgent, ips, fileName) => {
-  let url = `/api/log/${fileName}?ips=${ips}`;
+  let url = `/api/downloadLogFile?ips=${ips}&file=${fileName}`;
   return commonGet(superAgent, url);
 };
 

--- a/test/lib/admin/api_log.test.js
+++ b/test/lib/admin/api_log.test.js
@@ -248,10 +248,15 @@ describe('api_log.test.js', () => {
       .end(done);
   });
 
-  it('should return 404 when fileName illegal', function (done) {
+  it('should return error when fileName illegal', function (done) {
     let fileName = `../../server.${moment().format('YYYY-MM-DD')}.log`;
     common.downloadLog(agent, ips, fileName)
-      .expect(404)
+      .expect(200)
+      .expect('content-type', /application\/json/)
+      .expect(function (res) {
+        res.body.code.should.eql('ERROR');
+        res.body.message.should.match(/logpath illegal/);
+      })
       .end(done);
   });
   it('should return error when fileName not found', function (done) {


### PR DESCRIPTION
将日志下载接口文件名位置放在query，支持 '\\'