### PR TITLE
Prevent admin exit on requesting /api/health in some cases

### DIFF
--- a/lib/admin/single_api/system.js
+++ b/lib/admin/single_api/system.js
@@ -20,15 +20,17 @@ exports.healthCheck = function (req, res) {
   message.send({
     action: '$healthCheck',
     arguments: [],
-    timeout: 15000 // 5秒
+    timeout: 15000 // 15秒
   }, function (err, data) {
     if (err) {
       res.statusCode = 404;
     }
     if (data && data.length > 0) {
       res.statusCode = 404;
+      res.end(data.join('\n'));
+    } else {
+      res.end("No data.\n");
     }
-    res.end(data.join('\n'));
   });
 };
 

--- a/lib/admin/single_api/system.js
+++ b/lib/admin/single_api/system.js
@@ -29,7 +29,7 @@ exports.healthCheck = function (req, res) {
       res.statusCode = 404;
       res.end(data.join('\n'));
     } else {
-      res.end("No data.\n");
+      res.end('No data.\n');
     }
   });
 };

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -340,14 +340,15 @@ class HCWorker extends EventEmitter {
 
     let appId = this.appId;
     let tid = worker.threadId;
-    let pid = process.pid;
+    // To prevent subsequent logging with pid: undefined
+    this.pid = process.pid;
     worker.stdout.on('data', (chunk) => {
       // eslint-disable-next-line
-      console.log(`${log.getTime()} ${appId} #${pid} [Thread ${tid}] [stdout] `, chunk.toString().trimRight());
+      console.log(`${log.getTime()} ${appId} #${this.pid} [Thread ${tid}] [stdout] `, chunk.toString().trimRight());
     });
     worker.stderr.on('data', (chunk) => {
       // eslint-disable-next-line
-      console.error(`${log.getTime()} ${appId} #${pid} [Thread ${tid}] [stderr]`, chunk.toString().trimRight());
+      console.error(`${log.getTime()} ${appId} #${this.pid} [Thread ${tid}] [stderr]`, chunk.toString().trimRight());
     });
     return worker;
   }


### PR DESCRIPTION
1. 避免worker的日志打印为undefined
2. 避免某些情况下，针对/api/health的访问，导致admin exit