### PR TITLE
fix: cve problem of vm2

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
     "url": "https://github.com/node-honeycomb/honeycomb-server.git"
   },
   "license": "MIT",
+  "overrides": {
+      "vm2": "^3.9.15"
+  },
   "dependencies": {
     "@sindresorhus/df": "2.1.0",
     "async": "3.2.2",


### PR DESCRIPTION
参考：https://securityonline.info/cve-2023-29017-critical-rce-flaw-in-popular-vm2-javascript-sandbox/