### PR TITLE
vm2安全问题较多，通过升级degenerator移除vm2的依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "honeycomb-server",
   "version": "4.0.11",
-  "build": "1",
+  "build": "2",
   "description": "Honeycomb, the micro-app's container",
   "repository": {
     "type": "git",
@@ -9,7 +9,7 @@
   },
   "license": "MIT",
   "overrides": {
-      "vm2": "^3.9.19"
+    "degenerator": "^5.0.1"
   },
   "dependencies": {
     "@sindresorhus/df": "2.1.0",


### PR DESCRIPTION
urllib -> proxy-agent -> pac-proxy-agent -> pac-resolver -> degenerator -> vm2

来自 寸行 的建议。
